### PR TITLE
Solution 080 too complex

### DIFF
--- a/CocoaheadsCodeGolf.xcodeproj/project.pbxproj
+++ b/CocoaheadsCodeGolf.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		269A58DE20B1822300872989 /* HeatWavesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A58DD20B1822300872989 /* HeatWavesTests.swift */; };
 		269A58E020B1822300872989 /* HeatWaves.h in Headers */ = {isa = PBXBuildFile; fileRef = 269A58D220B1822300872989 /* HeatWaves.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		269A58E820B1823C00872989 /* HeatWaves.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A58E720B1823C00872989 /* HeatWaves.swift */; };
+		3448F28C20B80F38008CC209 /* HeatWaves-readable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3448F28B20B80F38008CC209 /* HeatWaves-readable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +33,7 @@
 		269A58DF20B1822300872989 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		269A58E720B1823C00872989 /* HeatWaves.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatWaves.swift; sourceTree = "<group>"; };
 		269A58ED20B2D13D00872989 /* CharacterCount.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterCount.txt; sourceTree = "<group>"; };
+		3448F28B20B80F38008CC209 /* HeatWaves-readable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HeatWaves-readable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +80,7 @@
 				269A58E720B1823C00872989 /* HeatWaves.swift */,
 				269A58ED20B2D13D00872989 /* CharacterCount.txt */,
 				269A58D320B1822300872989 /* Info.plist */,
+				3448F28B20B80F38008CC209 /* HeatWaves-readable.swift */,
 			);
 			path = HeatWaves;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3448F28C20B80F38008CC209 /* HeatWaves-readable.swift in Sources */,
 				269A58E820B1823C00872989 /* HeatWaves.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HeatWaves/CharacterCount.txt
+++ b/HeatWaves/CharacterCount.txt
@@ -1,1 +1,1 @@
-12 bytes.
+80 bytes.

--- a/HeatWaves/HeatWaves-readable.swift
+++ b/HeatWaves/HeatWaves-readable.swift
@@ -2,8 +2,9 @@
 //  HeatWaves-readable.swift
 //  HeatWaves
 //
-//  Created by Sven Titgemeyer on 20.05.18.
-//  Edited by Udo Borkowski on 2018-05-25.
+//  Solution by Udo Borkowski (2018-05-25)
+//
+//  FOR THE PUBLIC DOMAIN
 //
 
 // Background
@@ -30,5 +31,30 @@
 // in 'HeatWaves.swift' but is intended for a reader who wants to understand
 // the code better. So it includes comments, whitespaces, better names, ....)
 public func isHeatWaveIncludedIn_readable(waves w: [Int]) -> Bool {
-    return false // no heat wave found
+    
+    // This solution is similar to "solution-087-Reduce-Factors" but makes use of an
+    // extra nested closure. It looks like this is "too much" for the current
+    // Swift compiler (4.1) as it reports the error:
+    //
+    //     Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions
+    //
+    // Too bad, as this is an 80 bytes solution !
+    //
+    // BTW: as suggested in the error message breaking up the expression solves the issue.
+    // E.g. if we extract the nested closure into an outer variable 'f':
+    //
+    //      let f={$0%27==0&&$0>81 ?0:$0};return w.reduce(1,{f($1>24 ?$0*($1>29 ?3:2):$0>0 ?1:0)})<1
+    //
+    // the code compiles and the tests are green. However we are now at 88 bytes!
+    //
+    
+    // Expect a compile error in the next line. See comment above...
+    return w.reduce(1,{($1>24 ?$0*($1>29 ?3:2):$0>0 ?1:0){$0%27==0&&$0>81 ?0:$0}})<1
+
+    // This solution is not yet fully documented. but you may have a look at "solution-087-Reduce-Factors"
+    // to get an idea how it works. The following lines align both solutions and show the differences:
+    //
+    // "solution-080-TooComplex"        return w.reduce(1,{(     $1>24 ?$0*($1>29 ?3:2):$0>0 ?1:0){      $0%27==0&&$0>81 ?0:$0}})<1
+    // "solution-087-Reduce-Factors"    return w.reduce(1,{let n=$1>24 ?$0*($1>29 ?3:2):$0>0 ?1:0;return n %27==0&&n >81 ?0:n })<1
+
 }

--- a/HeatWaves/HeatWaves-readable.swift
+++ b/HeatWaves/HeatWaves-readable.swift
@@ -1,9 +1,9 @@
 //
-//  HeatWaves.swift
+//  HeatWaves-readable.swift
 //  HeatWaves
 //
 //  Created by Sven Titgemeyer on 20.05.18.
-//  Copyright © 2018 Cocoaheads Aachen. All rights reserved.
+//  Edited by Udo Borkowski on 2018-05-25.
 //
 
 // Background
@@ -26,7 +26,9 @@
 //
 // The shortest answer in bytes wins.
 //
-// (see "HeadWaves-readable.swift" for a readable/commented version of this code)
-public func isHeatWaveIncludedIn(waves w: [Int]) -> Bool {
-    return false
+// (This function contains the same code/algorithm as 'isHeatWaveIncludedIn'
+// in 'HeadWaves.swift' but is intended for a reader who wants to understand
+// the code better. So it includes comments, whitespaces, better names, ....)
+public func isHeatWaveIncludedIn_readable(waves w: [Int]) -> Bool {
+    return false // no head wave found
 }

--- a/HeatWaves/HeatWaves-readable.swift
+++ b/HeatWaves/HeatWaves-readable.swift
@@ -27,8 +27,8 @@
 // The shortest answer in bytes wins.
 //
 // (This function contains the same code/algorithm as 'isHeatWaveIncludedIn'
-// in 'HeadWaves.swift' but is intended for a reader who wants to understand
+// in 'HeatWaves.swift' but is intended for a reader who wants to understand
 // the code better. So it includes comments, whitespaces, better names, ....)
 public func isHeatWaveIncludedIn_readable(waves w: [Int]) -> Bool {
-    return false // no head wave found
+    return false // no heat wave found
 }

--- a/HeatWaves/HeatWaves.swift
+++ b/HeatWaves/HeatWaves.swift
@@ -2,8 +2,9 @@
 //  HeatWaves.swift
 //  HeatWaves
 //
-//  Created by Sven Titgemeyer on 20.05.18.
-//  Copyright © 2018 Cocoaheads Aachen. All rights reserved.
+//  Solution by Udo Borkowski (2018-05-25)
+//
+//  FOR THE PUBLIC DOMAIN
 //
 
 // Background
@@ -27,6 +28,13 @@
 // The shortest answer in bytes wins.
 //
 // (see "HeatWaves-readable.swift" for a readable/commented version of this code)
+//
+// NOTICE: The following code gives a compile error when running in Xcode 4.1 (Swift 4.1):
+//
+//      "Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions"
+//
+// This is most likely caused by Swift's algorithm that resolves overloaded functions. In case this algorithm
+// is improved in a later Swift version this code may compile and run....
 public func isHeatWaveIncludedIn(waves w: [Int]) -> Bool {
-    return false
+    return w.reduce(1,{($1>24 ?$0*($1>29 ?3:2):$0>0 ?1:0){$0%27==0&&$0>81 ?0:$0}})<1
 }

--- a/HeatWaves/HeatWaves.swift
+++ b/HeatWaves/HeatWaves.swift
@@ -26,7 +26,7 @@
 //
 // The shortest answer in bytes wins.
 //
-// (see "HeadWaves-readable.swift" for a readable/commented version of this code)
+// (see "HeatWaves-readable.swift" for a readable/commented version of this code)
 public func isHeatWaveIncludedIn(waves w: [Int]) -> Bool {
     return false
 }


### PR DESCRIPTION
An improved "Reduce-Factors" solution "too complex" for Swift 4.1 (80 bytes)

Swift 4.1 will not compile this code but report the error:

     "Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions"

Maybe a later version of the Swift compiler can handle this...